### PR TITLE
Remove live data emphasis and tone down real-time language

### DIFF
--- a/ccc-schedule-examples/rio-hondo-live/index.html
+++ b/ccc-schedule-examples/rio-hondo-live/index.html
@@ -4,7 +4,7 @@
     <!-- Required meta tags -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Rio Hondo College - Live Schedule Demo</title>
+    <title>Rio Hondo College - Schedule Demo</title>
     
     <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico"/>
     <!-- Bootstrap CSS -->
@@ -31,22 +31,6 @@
             background-color: #e8f4f8;
             border-left: 4px solid #004B87;
         }
-        .live-indicator {
-            display: inline-flex;
-            align-items: center;
-            background-color: #28a745;
-            color: white;
-            padding: 0.25rem 0.75rem;
-            border-radius: 20px;
-            font-size: 0.875rem;
-            font-weight: 500;
-            animation: pulse 2s infinite;
-        }
-        @keyframes pulse {
-            0% { opacity: 1; }
-            50% { opacity: 0.8; }
-            100% { opacity: 1; }
-        }
         .spin {
             animation: spin 1s linear infinite;
         }
@@ -66,13 +50,7 @@
                 </a>
                 <div class="text-center">
                     <h3 class="mb-0">Rio Hondo College</h3>
-                    <small class="rio-hondo-accent">Live Schedule Demo - Fall 2025</small>
-                    <div class="mt-2">
-                        <span class="live-indicator">
-                            <i class="bi bi-circle-fill me-1" style="font-size: 0.5rem;"></i>
-                            LIVE DATA
-                        </span>
-                    </div>
+                    <small class="rio-hondo-accent">Schedule Demo - Fall 2025</small>
                 </div>
                 <div style="width: 120px;"></div> <!-- Spacer for centering -->
             </div>
@@ -87,11 +65,11 @@
                 <div class="d-flex align-items-start">
                     <i class="bi bi-info-circle-fill me-3 flex-shrink-0" style="font-size: 1.5rem; color: #004B87;"></i>
                     <div>
-                        <strong>Rio Hondo College Live Demo</strong><br>
-                        This demonstration connects to live data from Rio Hondo College's public schedule. 
-                        Data is fetched in real-time from the <a href="https://github.com/jmcpheron/ccc-schedule-collector" target="_blank">CCC Schedule Collector</a> repository.
+                        <strong>Rio Hondo College Schedule Demo</strong><br>
+                        This demonstration uses data from Rio Hondo College's public schedule, 
+                        collected via the <a href="https://github.com/jmcpheron/ccc-schedule-collector" target="_blank">CCC Schedule Collector</a> repository.
                         <br>
-                        <small class="text-muted" id="data-status">Loading live data...</small>
+                        <small class="text-muted" id="data-status">Loading schedule data...</small>
                     </div>
                 </div>
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
@@ -255,10 +233,10 @@
     <footer class="mt-5 py-3 bg-light">
         <div class="container text-center">
             <p class="text-muted mb-0">
-                Rio Hondo College Live Schedule Demo | 
+                Rio Hondo College Schedule Demo | 
                 <a href="https://github.com/jmcpheron/ccc-schedule" target="_blank">CCC Schedule Project</a> | 
-                <a href="https://github.com/jmcpheron/ccc-schedule-collector" target="_blank">Live Data Source</a> | 
-                <a href="../rio-hondo/" class="text-primary">View Static Demo</a>
+                <a href="https://github.com/jmcpheron/ccc-schedule-collector" target="_blank">Data Source</a> | 
+                <a href="../rio-hondo/" class="text-primary">View Cached Version</a>
             </p>
         </div>
     </footer>

--- a/ccc-schedule-examples/rio-hondo-live/js/rio-hondo-live-schedule.js
+++ b/ccc-schedule-examples/rio-hondo-live/js/rio-hondo-live-schedule.js
@@ -1,6 +1,6 @@
 /**
- * Rio Hondo College Live Schedule JavaScript
- * Fetches and displays live data from the CCC Schedule Collector repository
+ * Rio Hondo College Schedule JavaScript
+ * Fetches and displays data from the CCC Schedule Collector repository
  */
 
 // Global variables
@@ -75,13 +75,13 @@ function initializeEventHandlers() {
 }
 
 /**
- * Load initial data from live GitHub repository
+ * Load initial data from GitHub repository
  */
 function loadInitialData() {
     // Show loading status
-    $('#data-status').html('<i class="bi bi-arrow-repeat spin"></i> Fetching live data...');
+    $('#data-status').html('<i class="bi bi-arrow-repeat spin"></i> Loading schedule data...');
     
-    // Load course data from live GitHub repository
+    // Load course data from GitHub repository
     const symlinkUrl = 'https://raw.githubusercontent.com/jmcpheron/ccc-schedule-collector/main/data/schedule_202570_latest.json';
     
     // First, fetch the symlink content to get the actual filename
@@ -142,7 +142,7 @@ function loadInitialData() {
                         'Unknown';
                     const courseCount = allCourses.length;
                     $('#data-status').html(
-                        `<i class="bi bi-check-circle text-success"></i> Live data loaded | ` +
+                        `<i class="bi bi-check-circle text-success"></i> Data loaded | ` +
                         `Last updated: ${collectedDate} | ${courseCount} courses available`
                     );
                 } else if (data.collection_timestamp) {
@@ -151,12 +151,12 @@ function loadInitialData() {
                     const sectionCount = data.courses.length;
                     const courseCount = allCourses.length;
                     $('#data-status').html(
-                        `<i class="bi bi-check-circle text-success"></i> Live data loaded | ` +
+                        `<i class="bi bi-check-circle text-success"></i> Data loaded | ` +
                         `Last updated: ${collectedDate} | ${courseCount} courses with ${sectionCount} sections`
                     );
                 } else {
                     $('#data-status').html(
-                        `<i class="bi bi-check-circle text-success"></i> Live data loaded | ${allCourses.length} courses available`
+                        `<i class="bi bi-check-circle text-success"></i> Data loaded | ${allCourses.length} courses available`
                     );
                 }
             } else if (data.schedule && data.schedule.courses) {
@@ -193,17 +193,17 @@ function loadInitialData() {
             }
         })
         .fail(function(jqXHR, textStatus, errorThrown) {
-            console.error('Failed to load live data:', textStatus, errorThrown);
+            console.error('Failed to load data:', textStatus, errorThrown);
             $('#loading-spinner').html(
                 '<div class="alert alert-danger">' +
-                '<h5><i class="bi bi-exclamation-triangle-fill"></i> Failed to Load Live Data</h5>' +
-                '<p>Unable to fetch live schedule data from the repository.</p>' +
+                '<h5><i class="bi bi-exclamation-triangle-fill"></i> Failed to Load Schedule Data</h5>' +
+                '<p>Unable to fetch schedule data from the repository.</p>' +
                 '<p class="mb-2">Error: ' + (errorThrown || textStatus) + '</p>' +
-                '<a href="../rio-hondo/" class="btn btn-primary btn-sm">View Static Demo Instead</a>' +
+                '<a href="../rio-hondo/" class="btn btn-primary btn-sm">View Cached Version</a>' +
                 '</div>'
             );
             $('#data-status').html(
-                '<i class="bi bi-x-circle text-danger"></i> Live data unavailable'
+                '<i class="bi bi-x-circle text-danger"></i> Data unavailable'
             );
         });
     })
@@ -211,14 +211,14 @@ function loadInitialData() {
         console.error('Failed to fetch symlink:', textStatus, errorThrown);
         $('#loading-spinner').html(
             '<div class="alert alert-danger">' +
-            '<h5><i class="bi bi-exclamation-triangle-fill"></i> Failed to Load Live Data</h5>' +
-            '<p>Unable to fetch schedule data reference from the repository.</p>' +
+            '<h5><i class="bi bi-exclamation-triangle-fill"></i> Failed to Load Schedule Data</h5>' +
+            '<p>Unable to fetch schedule data from the repository.</p>' +
             '<p class="mb-2">Error: ' + (errorThrown || textStatus) + '</p>' +
-            '<a href="../rio-hondo/" class="btn btn-primary btn-sm">View Static Demo Instead</a>' +
+            '<a href="../rio-hondo/" class="btn btn-primary btn-sm">View Cached Version</a>' +
             '</div>'
         );
         $('#data-status').html(
-            '<i class="bi bi-x-circle text-danger"></i> Live data unavailable'
+            '<i class="bi bi-x-circle text-danger"></i> Data unavailable'
         );
     });
 }

--- a/ccc-schedule-examples/rio-hondo-modern/index.html
+++ b/ccc-schedule-examples/rio-hondo-modern/index.html
@@ -796,9 +796,6 @@
         <div class="nav-container">
             <div class="logo-section">
                 <h1>Rio Hondo College</h1>
-                <span class="chip" style="background: var(--success); color: white; font-size: 0.75rem; padding: 0.25rem 0.625rem;">
-                    <i class="bi bi-circle-fill" style="font-size: 0.375rem;"></i> LIVE
-                </span>
             </div>
             
             <div class="nav-actions">

--- a/ccc-schedule-examples/rio-hondo/index.html
+++ b/ccc-schedule-examples/rio-hondo/index.html
@@ -64,8 +64,8 @@
                         <br>
                         <small class="text-muted">Data collected on: July 23, 2025 | 611 courses available</small>
                         <div class="mt-2">
-                            <a href="../rio-hondo-live/" class="btn btn-success btn-sm">
-                                <i class="bi bi-circle-fill" style="font-size: 0.5rem;"></i> View Live Version
+                            <a href="../rio-hondo-live/" class="btn btn-primary btn-sm">
+                                <i class="bi bi-arrow-clockwise"></i> View Latest Data
                             </a>
                         </div>
                     </div>


### PR DESCRIPTION
- Remove all "LIVE" badges from both modern and live Rio Hondo versions
- Change "Live Schedule Demo" to just "Schedule Demo" in titles
- Update all references from "live data" to just "data" or "schedule data"
- Change "View Live Version" to "View Latest Data" with refresh icon
- Change "View Static Demo" to "View Cached Version" for clarity
- Update error messages to be less emphatic about real-time nature
- Remove pulsing green indicators that suggested constant updates

The functionality remains the same (still fetches from GitHub), but the UI language now better reflects that this is periodically updated data rather than a real-time feed.

🤖 Generated with [Claude Code](https://claude.ai/code)