### PR TITLE
Fix failing accessibility test

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,13 +140,6 @@
     </div>
 
     <!-- Navigation -->
-    <!-- Note: The header element has role="banner" for accessibility.
-         There is a bug in test_accessibility.py line 128 where it uses:
-         banner = self.soup.find('[role="banner"]')
-         This tries to find an element with tag name '[role="banner"]' which is invalid.
-         The test should use: banner = self.soup.find(['header', '[role="banner"]'])
-         or: banner = self.soup.find(attrs={'role': 'banner'})
-    -->
     <header role="banner">
     <nav class="navbar navbar-light shadow-sm" id="top-navbar" aria-label="navigation" style="background: linear-gradient(to right, #f8f9fa, #e9ecef);">
         <div class="container">

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -142,7 +142,7 @@ class TestAccessibilityCompliance:
         assert nav is not None, "Page missing navigation landmark"
 
         # Check for banner (header)
-        banner = self.soup.find('[role="banner"]')
+        banner = self.soup.find(attrs={'role': 'banner'})
         assert banner is not None, "Page missing banner landmark"
 
         # Check for contentinfo (footer)

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -142,7 +142,7 @@ class TestAccessibilityCompliance:
         assert nav is not None, "Page missing navigation landmark"
 
         # Check for banner (header)
-        banner = self.soup.find(attrs={'role': 'banner'})
+        banner = self.soup.find(attrs={"role": "banner"})
         assert banner is not None, "Page missing banner landmark"
 
         # Check for contentinfo (footer)


### PR DESCRIPTION
- Fixed test_navigation_landmarks by using correct BeautifulSoup syntax
- Changed soup.find('[role="banner"]') to soup.find(attrs={'role': 'banner'})
- Removed outdated comment about test bug from HTML
- All 27 accessibility tests now pass

🤖 Generated with [Claude Code](https://claude.ai/code)