### PR TITLE
Add Citrus College schedule demo and improve course/section clarity

### DIFF
--- a/ccc-schedule-examples/citrus/index.html
+++ b/ccc-schedule-examples/citrus/index.html
@@ -1,0 +1,523 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5, user-scalable=yes">
+    <title>Citrus College - Schedule Demo</title>
+    
+    <link rel="shortcut icon" type="image/x-icon" href="../../favicon.ico"/>
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+    
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.0/font/bootstrap-icons.css">
+    
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="../../css/schedule.css">
+    
+    <style>
+        .citrus-header {
+            background-color: #003366;
+            color: white;
+            padding: 1rem 0;
+        }
+        .citrus-accent {
+            color: #FF6600;
+        }
+        .demo-notice {
+            background-color: #e8f4f8;
+            border-left: 4px solid #003366;
+        }
+        
+        /* Mobile-first approach */
+        .filters-section {
+            background: #f8f9fa;
+            border-radius: 8px;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+        
+        .mobile-filter-toggle {
+            display: none;
+            width: 100%;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0.75rem;
+            background: white;
+            border: 1px solid #dee2e6;
+            border-radius: 8px;
+            margin-bottom: 1rem;
+        }
+        
+        /* Mobile styles */
+        @media (max-width: 767px) {
+            .citrus-header {
+                padding: 0.75rem 0;
+            }
+            .citrus-header h3 {
+                font-size: 1.1rem;
+            }
+            .citrus-header small {
+                font-size: 0.7rem;
+            }
+            
+            /* Hide back button text on very small screens */
+            @media (max-width: 375px) {
+                .btn-outline-light span {
+                    display: none !important;
+                }
+            }
+            
+            /* Collapsible filters */
+            .mobile-filter-toggle {
+                display: flex;
+            }
+            
+            .filters-section {
+                display: none;
+                margin-top: 0;
+            }
+            
+            .filters-section.show {
+                display: block;
+            }
+            
+            /* Search section */
+            #search_input_main {
+                font-size: 16px;
+                border-radius: 25px;
+                padding: 0.75rem 1.25rem;
+            }
+            
+            .search-button-group {
+                margin-top: 0.75rem;
+            }
+            
+            .search-button-group button {
+                padding: 0.5rem 1rem;
+                font-size: 0.9rem;
+            }
+            
+            /* Demo notice */
+            .demo-notice {
+                font-size: 0.8rem;
+                padding: 0.75rem;
+            }
+            
+            .demo-notice i {
+                display: none;
+            }
+            
+            /* Results header */
+            #results-container .d-flex {
+                gap: 0.75rem;
+            }
+            
+            #result-count {
+                font-size: 1rem;
+            }
+            
+            .btn-group {
+                width: 100%;
+            }
+            
+            .btn-group label {
+                padding: 0.375rem 0.75rem;
+                font-size: 0.8rem;
+            }
+            
+            .btn-group label i {
+                font-size: 0.875rem;
+            }
+            
+            /* Course cards */
+            .card {
+                margin-bottom: 0.75rem;
+                border-radius: 12px;
+                overflow: hidden;
+                box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            }
+            
+            .card-header {
+                padding: 0.75rem;
+            }
+            
+            .card-header h5 {
+                font-size: 0.95rem;
+                margin-bottom: 0.25rem;
+            }
+            
+            .card-body {
+                padding: 0.75rem;
+            }
+            
+            /* Mobile table in cards */
+            .card .table {
+                font-size: 0.8rem;
+            }
+            
+            .card .table th,
+            .card .table td {
+                padding: 0.5rem 0.25rem;
+            }
+            
+            /* Hide less important columns on mobile */
+            .card .table th:nth-child(5),
+            .card .table td:nth-child(5) {
+                display: none;
+            }
+            
+            /* Table view */
+            .table-responsive {
+                margin: 0 -15px;
+            }
+            
+            .table {
+                font-size: 0.75rem;
+            }
+            
+            .table th,
+            .table td {
+                padding: 0.5rem 0.25rem;
+                white-space: nowrap;
+            }
+            
+            /* Pagination */
+            .pagination {
+                justify-content: center;
+                flex-wrap: wrap;
+            }
+            
+            .page-link {
+                padding: 0.375rem 0.5rem;
+                font-size: 0.875rem;
+            }
+        }
+        
+        /* Additional mobile optimizations */
+        .search-button-group {
+            display: flex;
+            gap: 0.5rem;
+            width: 100%;
+        }
+        
+        @media (max-width: 767px) {
+            .search-button-group {
+                flex-direction: row;
+            }
+            .search-button-group button {
+                flex: 1;
+            }
+        }
+        
+        /* Improve filter layout on mobile */
+        @media (max-width: 575px) {
+            .form-label {
+                font-size: 0.875rem;
+                margin-bottom: 0.25rem;
+            }
+            
+            .form-select,
+            .form-control {
+                font-size: 0.875rem;
+                padding: 0.5rem 0.75rem;
+            }
+            
+            .btn-outline-success,
+            .btn-outline-primary,
+            .btn-secondary {
+                font-size: 0.875rem;
+                padding: 0.5rem;
+            }
+        }
+        
+        /* Mobile section cards */
+        .section-mobile {
+            background: #f8f9fa;
+            font-size: 0.875rem;
+        }
+        
+        .section-mobile strong {
+            color: #003366;
+        }
+        
+        /* Clickable sections */
+        .section-clickable {
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+        
+        .section-clickable:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+        }
+        
+        tr.section-clickable:hover {
+            background-color: #e8f4f8;
+            transform: none;
+            box-shadow: none;
+        }
+        
+        /* Hide table view option on very small screens */
+        @media (max-width: 480px) {
+            #table-view,
+            label[for="table-view"] {
+                display: none;
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="navbar navbar-dark citrus-header" id="top-navbar" aria-label="navigation">
+        <div class="container">
+            <div class="d-flex justify-content-between align-items-center w-100">
+                <a href="../../index.html" class="btn btn-outline-light btn-sm">
+                    <i class="bi bi-arrow-left"></i> <span class="d-none d-sm-inline">Back to Main</span>
+                </a>
+                <div class="text-center flex-grow-1">
+                    <h3 class="mb-0">Citrus College</h3>
+                    <small class="citrus-accent">Schedule Demo - Fall 2025</small>
+                </div>
+                <div class="d-none d-sm-block" style="width: 120px;"></div> <!-- Spacer for centering -->
+            </div>
+        </div>
+    </nav>
+
+    <!-- Main Search Container -->
+    <div class="container">
+        <div class="mt-4">
+            <!-- Demo Notice -->
+            <div class="alert demo-notice alert-dismissible fade show" role="alert">
+                <div class="d-flex align-items-start">
+                    <i class="bi bi-info-circle-fill me-3 flex-shrink-0" style="font-size: 1.5rem; color: #003366;"></i>
+                    <div>
+                        <strong>Citrus College Demo</strong><br>
+                        This is a demonstration using data collected from Citrus College's public schedule. 
+                        The data was gathered using the <a href="https://github.com/jmcpheron/ccc-schedule-collector" target="_blank">CCC Schedule Collector</a>.
+                        <br>
+                        <small class="text-muted">Data collected on: July 23, 2025 | 611 courses available</small>
+                    </div>
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+
+            <form id="search-form" action=".">
+                <div class="row align-items-end">
+                    <div class="col-12">
+                        <h1 class="text-center mb-3 mb-md-4">Search Citrus Classes</h1>
+                    </div>
+                    <div class="col-12 mb-3">
+                        <input id="search_input_main" class="form-control form-control-lg" type="search" placeholder="Search courses..." aria-label="#search_input_main">
+                        <div class="search-button-group">
+                            <button class="btn btn-primary btn-lg" type="submit" id="button-search" value="ALL" title="Search all sections"><i class="bi bi-search"></i> <span class="d-none d-sm-inline">All</span></button>
+                            <button class="btn btn-success btn-lg" type="submit" id="button-search-open" value="OPEN" title="Search open sections only"><i class="bi bi-search"></i> <span class="d-none d-sm-inline">Open</span></button>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- Mobile filter toggle -->
+                <div class="mobile-filter-toggle" onclick="toggleFilters()">
+                    <span><i class="bi bi-funnel"></i> Filters</span>
+                    <i class="bi bi-chevron-down" id="filter-chevron"></i>
+                </div>
+                
+                <!-- Filters section -->
+                <div class="filters-section" id="filters-section">
+                <div class="row g-3 mb-3">
+                    <div class="col-sm-6 col-md-3">
+                        <label for="term-select" class="form-label">Term</label>
+                        <select class="form-select" id="term-select" aria-label="term select">
+                            <option value="202620" selected>Fall 2025</option>
+                        </select>
+                    </div>
+                    <div class="col-sm-6 col-md-3">
+                        <label for="subject-select" class="form-label">Subject</label>
+                        <select class="form-select" aria-label="Select Subject" id="subject-select">
+                            <option value="">All Subjects</option>
+                        </select>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <label for="units-min" class="form-label">Min Units</label>
+                        <input type="number" class="form-control" id="units-min" min="0" max="6" step="0.5" placeholder="0">
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <label for="units-max" class="form-label">Max Units</label>
+                        <input type="number" class="form-control" id="units-max" min="0" max="6" step="0.5" placeholder="6">
+                    </div>
+                </div>
+                <div class="row g-3 mb-3">
+                    <div class="col-sm-6 col-md-3">
+                        <div id="instr-method-label">Instructional Mode</div>
+                        <div class="dropdown" id="instr-method-drop-down">
+                            <button class="form-select button-select dropdown-toggle" type="button" id="instr-method-button" data-bs-toggle="dropdown" aria-expanded="false">
+                                All Modes
+                            </button>
+                            <ul class="dropdown-menu" aria-labelledby="instr-method-label">
+                                <li class="dropdown-item">
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="flexRadioInstrMethod" id="flexRadioInstrMethod1" value="In Person">
+                                        <label class="form-check-label" for="flexRadioInstrMethod1">
+                                            In-Person
+                                        </label>
+                                    </div>
+                                </li>
+                                <li class="dropdown-item">
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="flexRadioInstrMethod" id="flexRadioInstrMethod2" value="Hybrid">
+                                        <label class="form-check-label" for="flexRadioInstrMethod2">
+                                            Hybrid
+                                        </label>
+                                    </div>
+                                </li>
+                                <li class="dropdown-item">
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="flexRadioInstrMethod" id="flexRadioInstrMethod3" value="Online">
+                                        <label class="form-check-label" for="flexRadioInstrMethod3">
+                                            Online
+                                        </label>
+                                    </div>
+                                </li>
+                                <li class="dropdown-item">
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="flexRadioInstrMethod" id="flexRadioInstrMethod4" value="Arranged">
+                                        <label class="form-check-label" for="flexRadioInstrMethod4">
+                                            Arranged
+                                        </label>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-3">
+                        <label class="form-label">Open Classes Only</label>
+                        <div>
+                            <input type="checkbox" class="btn-check" id="open-only" autocomplete="off">
+                            <label class="btn btn-outline-success w-100" for="open-only">Show Open Only</label>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-3">
+                        <label class="form-label">Zero Textbook Cost</label>
+                        <div>
+                            <input type="checkbox" class="btn-check" id="ztc-only" autocomplete="off">
+                            <label class="btn btn-outline-primary w-100" for="ztc-only">ZTC Courses</label>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-3">
+                        <label class="form-label d-none d-md-block">&nbsp;</label>
+                        <button type="button" class="btn btn-secondary w-100" id="reset-filters">
+                            <i class="bi bi-arrow-clockwise"></i> Reset Filters
+                        </button>
+                    </div>
+                </div>
+                </div>
+            </form>
+        </div>
+        
+        <!-- Results Container -->
+        <div id="loading-spinner" class="text-center my-5">
+            <div class="spinner-border text-primary" role="status">
+                <span class="visually-hidden">Loading...</span>
+            </div>
+            <p class="mt-2">Loading schedule data...</p>
+        </div>
+
+        <div id="results-container" style="display: none;">
+            <div class="d-flex flex-column flex-sm-row justify-content-between align-items-start align-items-sm-center mb-3 gap-2">
+                <h5 id="result-count" class="mb-0">0 courses found</h5>
+                <div class="btn-group" role="group">
+                    <input type="radio" class="btn-check" name="view-mode" id="card-view" checked>
+                    <label class="btn btn-outline-primary" for="card-view">
+                        <i class="bi bi-grid-3x2-gap"></i> Card View
+                    </label>
+                    <input type="radio" class="btn-check" name="view-mode" id="table-view">
+                    <label class="btn btn-outline-primary" for="table-view">
+                        <i class="bi bi-table"></i> Table View
+                    </label>
+                </div>
+            </div>
+
+            <div id="no-results" class="alert alert-info" style="display: none;">
+                <i class="bi bi-info-circle"></i> No courses found matching your criteria. Try adjusting your filters.
+            </div>
+
+            <div id="card-view-container" class="row g-3"></div>
+            <div id="table-view-container" style="display: none;">
+                <div class="table-responsive">
+                    <table class="table table-hover">
+                        <thead>
+                            <tr>
+                                <th>CRN</th>
+                                <th>Course</th>
+                                <th>Title</th>
+                                <th>Instructor</th>
+                                <th>Days/Times</th>
+                                <th>Location</th>
+                                <th>Units</th>
+                                <th>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody id="table-body"></tbody>
+                    </table>
+                </div>
+            </div>
+
+            <nav aria-label="Search results pagination">
+                <ul class="pagination justify-content-center" id="pagination"></ul>
+            </nav>
+        </div>
+    </div>
+
+    <!-- Section Details Modal -->
+    <div class="modal fade" id="sectionDetailsModal" tabindex="-1" aria-labelledby="sectionDetailsModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="sectionDetailsModalLabel">Section Details</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body" id="sectionDetailsBody">
+                    <!-- Section details will be populated here -->
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="mt-5 py-3 bg-light">
+        <div class="container text-center">
+            <p class="text-muted mb-0">
+                Citrus College Schedule Demo | 
+                <a href="https://github.com/jmcpheron/ccc-schedule" target="_blank">CCC Schedule Project</a> | 
+                <a href="https://github.com/jmcpheron/ccc-schedule-collector" target="_blank">Data Collector</a>
+            </p>
+        </div>
+    </footer>
+
+    <!-- Rio Hondo specific JavaScript -->
+    <script src="js/citrus-schedule.js"></script>
+    <script>
+        // Toggle filters on mobile
+        function toggleFilters() {
+            const filtersSection = document.getElementById('filters-section');
+            const chevron = document.getElementById('filter-chevron');
+            
+            filtersSection.classList.toggle('show');
+            
+            if (filtersSection.classList.contains('show')) {
+                chevron.classList.remove('bi-chevron-down');
+                chevron.classList.add('bi-chevron-up');
+            } else {
+                chevron.classList.remove('bi-chevron-up');
+                chevron.classList.add('bi-chevron-down');
+            }
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
- Create new Citrus College demo site with custom branding (#003366 navy, #FF6600 orange)
- Update data URL to fetch from citrus/schedule_202620_latest.json
- Adapt JavaScript to handle Citrus data structure differences:
  - 12-hour time format (already formatted with AM/PM)
  - Date format (MM/DD)
  - Additional fields: section_type, weeks, book_link
- Improve both Rio Hondo and Citrus demos:
  - Show full timestamp with time and timezone
  - Clarify course vs section counts (e.g., "221 courses found (451 sections)")
  - Update demo notice to distinguish sections from unique courses

🤖 Generated with [Claude Code](https://claude.ai/code)