### PR TITLE
Fix timezone display for California schools

### DIFF
--- a/ccc-schedule-examples/citrus/js/citrus-schedule.js
+++ b/ccc-schedule-examples/citrus/js/citrus-schedule.js
@@ -193,12 +193,14 @@ function transformLiveData(data) {
 function updateDataCollectionDate(timestamp) {
     if (timestamp) {
         const date = new Date(timestamp);
+        // Force Pacific Time for California schools
         const formattedDate = date.toLocaleDateString('en-US', { 
             year: 'numeric', 
             month: 'long', 
             day: 'numeric',
             hour: 'numeric',
             minute: 'numeric',
+            timeZone: 'America/Los_Angeles',
             timeZoneName: 'short'
         });
         

--- a/ccc-schedule-examples/rio-hondo/js/rio-hondo-schedule.js
+++ b/ccc-schedule-examples/rio-hondo/js/rio-hondo-schedule.js
@@ -190,12 +190,14 @@ function transformLiveData(data) {
 function updateDataCollectionDate(timestamp) {
     if (timestamp) {
         const date = new Date(timestamp);
+        // Force Pacific Time for California schools
         const formattedDate = date.toLocaleDateString('en-US', { 
             year: 'numeric', 
             month: 'long', 
             day: 'numeric',
             hour: 'numeric',
             minute: 'numeric',
+            timeZone: 'America/Los_Angeles',
             timeZoneName: 'short'
         });
         


### PR DESCRIPTION
## Summary
- Fixed date display to show Pacific Time (PST/PDT) instead of user's local timezone
- Applied fix to both Rio Hondo and Citrus College schedule demos
- Ensures consistent date display for all users regardless of their location

## Problem
The data collection timestamps from the CCC Schedule Collector are in UTC, but were being displayed in the user's local timezone. This was confusing for users in different timezones who would see incorrect dates (e.g., a collection done at 8 PM PST on August 1st would show as August 2nd for users in Eastern Time).

## Solution
Updated the `updateDataCollectionDate()` function in both schedule JavaScript files to explicitly use Pacific Time (`America/Los_Angeles`) when formatting the date. This ensures all users see the correct date/time for when the data was collected, which is appropriate since all California Community Colleges are in the Pacific timezone.

## Test plan
- [ ] Visit the Rio Hondo schedule demo and verify the "Data collected on" date shows Pacific Time
- [ ] Visit the Citrus schedule demo and verify the "Data collected on" date shows Pacific Time
- [ ] Test from different timezones (or change system timezone) to ensure consistent display

🤖 Generated with [Claude Code](https://claude.ai/code)