### PR TITLE
Update date formatting in Citrus and Rio Hondo schedule scripts to us…

### DIFF
--- a/ccc-schedule-examples/citrus/js/citrus-schedule.js
+++ b/ccc-schedule-examples/citrus/js/citrus-schedule.js
@@ -194,7 +194,7 @@ function updateDataCollectionDate(timestamp) {
     if (timestamp) {
         const date = new Date(timestamp);
         // Force Pacific Time for California schools
-        const formattedDate = date.toLocaleDateString('en-US', { 
+        const formattedDate = date.toLocaleString('en-US', { 
             year: 'numeric', 
             month: 'long', 
             day: 'numeric',

--- a/ccc-schedule-examples/rio-hondo/js/rio-hondo-schedule.js
+++ b/ccc-schedule-examples/rio-hondo/js/rio-hondo-schedule.js
@@ -191,7 +191,7 @@ function updateDataCollectionDate(timestamp) {
     if (timestamp) {
         const date = new Date(timestamp);
         // Force Pacific Time for California schools
-        const formattedDate = date.toLocaleDateString('en-US', { 
+        const formattedDate = date.toLocaleString('en-US', { 
             year: 'numeric', 
             month: 'long', 
             day: 'numeric',


### PR DESCRIPTION
…e toLocaleString for improved clarity

- Changed date formatting from toLocaleDateString to toLocaleString in both Citrus and Rio Hondo schedule JavaScript files.
- This adjustment ensures that the full date and time are displayed, enhancing user experience by providing more detailed timestamp information.

🤖 Generated with [Claude Code](https://claude.ai/code)