### PR TITLE
Update data collection timestamp display in Citrus demo to show loadi…

### DIFF
--- a/ccc-schedule-examples/citrus/index.html
+++ b/ccc-schedule-examples/citrus/index.html
@@ -299,7 +299,7 @@
                         This is a demonstration using data collected from Citrus College's public schedule. 
                         The data was gathered using the <a href="https://github.com/jmcpheron/ccc-schedule-collector" target="_blank">CCC Schedule Collector</a>.
                         <br>
-                        <small class="text-muted">Data collected on: July 23, 2025 | 611 courses available</small>
+                        <small class="text-muted">Data collected on: Loading... | Loading...</small>
                     </div>
                 </div>
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>


### PR DESCRIPTION
…ng state

- Changed the data collection timestamp in the Citrus College schedule demo from a specific date to a loading state ("Loading...") to indicate that data is being fetched.
- This adjustment improves user experience by providing a clear indication that the data is in the process of being loaded.

🤖 Generated with [Claude Code](https://claude.ai/code)