### PR TITLE
Add Mt. SAC Schedule Demo with Full Branding Integration

### DIFF
--- a/ccc-schedule-examples/mtsac/index.html
+++ b/ccc-schedule-examples/mtsac/index.html
@@ -1,0 +1,568 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5, user-scalable=yes">
+    <title>Mt. SAC - Schedule Demo</title>
+    
+    <link rel="shortcut icon" type="image/x-icon" href="../../favicon.ico"/>
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+    
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.0/font/bootstrap-icons.css">
+    
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="../../css/schedule.css">
+    
+    <style>
+        .mtsac-header {
+            background-color: #9c182f;
+            color: white;
+            padding: 1rem 0;
+        }
+        .mtsac-accent {
+            color: #ffcd5b;
+        }
+        .demo-notice {
+            background-color: #f5f1f1;
+            border-left: 4px solid #9c182f;
+        }
+        
+        /* Mt. SAC Custom Brand Colors */
+        .mtsac-card-header {
+            background-color: #9c182f !important;
+            color: white !important;
+        }
+        
+        .btn-primary {
+            background-color: #9c182f;
+            border-color: #9c182f;
+        }
+        
+        .btn-primary:hover, .btn-primary:focus, .btn-primary:active {
+            background-color: #7d1325;
+            border-color: #7d1325;
+        }
+        
+        .btn-outline-primary {
+            color: #9c182f;
+            border-color: #9c182f;
+        }
+        
+        .btn-outline-primary:hover, .btn-outline-primary:focus, .btn-outline-primary:active {
+            background-color: #9c182f;
+            border-color: #9c182f;
+            color: white;
+        }
+        
+        .btn-check:checked + .btn-outline-primary {
+            background-color: #9c182f;
+            border-color: #9c182f;
+            color: white;
+        }
+        
+        .spinner-border.text-primary {
+            color: #9c182f !important;
+        }
+        
+        .text-primary {
+            color: #9c182f !important;
+        }
+        
+        .bg-primary {
+            background-color: #9c182f !important;
+        }
+        
+        /* Mobile-first approach */
+        .filters-section {
+            background: #f8f9fa;
+            border-radius: 8px;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+        
+        .mobile-filter-toggle {
+            display: none;
+            width: 100%;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0.75rem;
+            background: white;
+            border: 1px solid #dee2e6;
+            border-radius: 8px;
+            margin-bottom: 1rem;
+        }
+        
+        /* Mobile styles */
+        @media (max-width: 767px) {
+            .mtsac-header {
+                padding: 0.75rem 0;
+            }
+            .mtsac-header h3 {
+                font-size: 1.1rem;
+            }
+            .mtsac-header small {
+                font-size: 0.7rem;
+            }
+            
+            /* Hide back button text on very small screens */
+            @media (max-width: 375px) {
+                .btn-outline-light span {
+                    display: none !important;
+                }
+            }
+            
+            /* Collapsible filters */
+            .mobile-filter-toggle {
+                display: flex;
+            }
+            
+            .filters-section {
+                display: none;
+                margin-top: 0;
+            }
+            
+            .filters-section.show {
+                display: block;
+            }
+            
+            /* Search section */
+            #search_input_main {
+                font-size: 16px;
+                border-radius: 25px;
+                padding: 0.75rem 1.25rem;
+            }
+            
+            .search-button-group {
+                margin-top: 0.75rem;
+            }
+            
+            .search-button-group button {
+                padding: 0.5rem 1rem;
+                font-size: 0.9rem;
+            }
+            
+            /* Demo notice */
+            .demo-notice {
+                font-size: 0.8rem;
+                padding: 0.75rem;
+            }
+            
+            .demo-notice i {
+                display: none;
+            }
+            
+            /* Results header */
+            #results-container .d-flex {
+                gap: 0.75rem;
+            }
+            
+            #result-count {
+                font-size: 1rem;
+            }
+            
+            .btn-group {
+                width: 100%;
+            }
+            
+            .btn-group label {
+                padding: 0.375rem 0.75rem;
+                font-size: 0.8rem;
+            }
+            
+            .btn-group label i {
+                font-size: 0.875rem;
+            }
+            
+            /* Course cards */
+            .card {
+                margin-bottom: 0.75rem;
+                border-radius: 12px;
+                overflow: hidden;
+                box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            }
+            
+            .card-header {
+                padding: 0.75rem;
+            }
+            
+            .card-header h5 {
+                font-size: 0.95rem;
+                margin-bottom: 0.25rem;
+            }
+            
+            .card-body {
+                padding: 0.75rem;
+            }
+            
+            /* Mobile table in cards */
+            .card .table {
+                font-size: 0.8rem;
+            }
+            
+            .card .table th,
+            .card .table td {
+                padding: 0.5rem 0.25rem;
+            }
+            
+            /* Hide less important columns on mobile */
+            .card .table th:nth-child(5),
+            .card .table td:nth-child(5) {
+                display: none;
+            }
+            
+            /* Table view */
+            .table-responsive {
+                margin: 0 -15px;
+            }
+            
+            .table {
+                font-size: 0.75rem;
+            }
+            
+            .table th,
+            .table td {
+                padding: 0.5rem 0.25rem;
+                white-space: nowrap;
+            }
+            
+            /* Pagination */
+            .pagination {
+                justify-content: center;
+                flex-wrap: wrap;
+            }
+            
+            .page-link {
+                padding: 0.375rem 0.5rem;
+                font-size: 0.875rem;
+            }
+        }
+        
+        /* Additional mobile optimizations */
+        .search-button-group {
+            display: flex;
+            gap: 0.5rem;
+            width: 100%;
+        }
+        
+        @media (max-width: 767px) {
+            .search-button-group {
+                flex-direction: row;
+            }
+            .search-button-group button {
+                flex: 1;
+            }
+        }
+        
+        /* Improve filter layout on mobile */
+        @media (max-width: 575px) {
+            .form-label {
+                font-size: 0.875rem;
+                margin-bottom: 0.25rem;
+            }
+            
+            .form-select,
+            .form-control {
+                font-size: 0.875rem;
+                padding: 0.5rem 0.75rem;
+            }
+            
+            .btn-outline-success,
+            .btn-outline-primary,
+            .btn-secondary {
+                font-size: 0.875rem;
+                padding: 0.5rem;
+            }
+        }
+        
+        /* Mobile section cards */
+        .section-mobile {
+            background: #f8f9fa;
+            font-size: 0.875rem;
+        }
+        
+        .section-mobile strong {
+            color: #9c182f;
+        }
+        
+        /* Clickable sections */
+        .section-clickable {
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+        
+        .section-clickable:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+        }
+        
+        tr.section-clickable:hover {
+            background-color: #f5f1f1;
+            transform: none;
+            box-shadow: none;
+        }
+        
+        /* Hide table view option on very small screens */
+        @media (max-width: 480px) {
+            #table-view,
+            label[for="table-view"] {
+                display: none;
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="navbar navbar-dark mtsac-header" id="top-navbar" aria-label="navigation">
+        <div class="container">
+            <div class="d-flex justify-content-between align-items-center w-100">
+                <a href="../../index.html" class="btn btn-outline-light btn-sm">
+                    <i class="bi bi-arrow-left"></i> <span class="d-none d-sm-inline">Back to Main</span>
+                </a>
+                <div class="text-center flex-grow-1">
+                    <h3 class="mb-0">Mt. SAC</h3>
+                    <small class="mtsac-accent">Schedule Demo - Fall 2025</small>
+                </div>
+                <div class="d-none d-sm-block" style="width: 120px;"></div> <!-- Spacer for centering -->
+            </div>
+        </div>
+    </nav>
+
+    <!-- Main Search Container -->
+    <div class="container">
+        <div class="mt-4">
+            <!-- Demo Notice -->
+            <div class="alert demo-notice alert-dismissible fade show" role="alert">
+                <div class="d-flex align-items-start">
+                    <i class="bi bi-info-circle-fill me-3 flex-shrink-0" style="font-size: 1.5rem; color: #9c182f;"></i>
+                    <div>
+                        <strong>Mt. SAC Demo</strong><br>
+                        This is a demonstration using data collected from Mountain San Antonio College's public schedule. 
+                        The data was gathered using the <a href="https://github.com/jmcpheron/ccc-schedule-collector" target="_blank">CCC Schedule Collector</a>.
+                        <br>
+                        <small class="text-muted">Data collected on: Loading... | Loading...</small>
+                    </div>
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+
+            <form id="search-form" action=".">
+                <div class="row align-items-end">
+                    <div class="col-12">
+                        <h1 class="text-center mb-3 mb-md-4">Search Mt. SAC Classes</h1>
+                    </div>
+                    <div class="col-12 mb-3">
+                        <input id="search_input_main" class="form-control form-control-lg" type="search" placeholder="Search courses..." aria-label="#search_input_main">
+                        <div class="search-button-group">
+                            <button class="btn btn-primary btn-lg" type="submit" id="button-search" value="ALL" title="Search all sections"><i class="bi bi-search"></i> <span class="d-none d-sm-inline">All</span></button>
+                            <button class="btn btn-success btn-lg" type="submit" id="button-search-open" value="OPEN" title="Search open sections only"><i class="bi bi-search"></i> <span class="d-none d-sm-inline">Open</span></button>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- Mobile filter toggle -->
+                <div class="mobile-filter-toggle" onclick="toggleFilters()">
+                    <span><i class="bi bi-funnel"></i> Filters</span>
+                    <i class="bi bi-chevron-down" id="filter-chevron"></i>
+                </div>
+                
+                <!-- Filters section -->
+                <div class="filters-section" id="filters-section">
+                <div class="row g-3 mb-3">
+                    <div class="col-sm-6 col-md-3">
+                        <label for="term-select" class="form-label">Term</label>
+                        <select class="form-select" id="term-select" aria-label="term select">
+                            <option value="202520" selected>Fall 2025</option>
+                        </select>
+                    </div>
+                    <div class="col-sm-6 col-md-3">
+                        <label for="subject-select" class="form-label">Subject</label>
+                        <select class="form-select" aria-label="Select Subject" id="subject-select">
+                            <option value="">All Subjects</option>
+                        </select>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <label for="units-min" class="form-label">Min Units</label>
+                        <input type="number" class="form-control" id="units-min" min="0" max="6" step="0.5" placeholder="0">
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <label for="units-max" class="form-label">Max Units</label>
+                        <input type="number" class="form-control" id="units-max" min="0" max="6" step="0.5" placeholder="6">
+                    </div>
+                </div>
+                <div class="row g-3 mb-3">
+                    <div class="col-sm-6 col-md-3">
+                        <div id="instr-method-label">Instructional Mode</div>
+                        <div class="dropdown" id="instr-method-drop-down">
+                            <button class="form-select button-select dropdown-toggle" type="button" id="instr-method-button" data-bs-toggle="dropdown" aria-expanded="false">
+                                All Modes
+                            </button>
+                            <ul class="dropdown-menu" aria-labelledby="instr-method-label">
+                                <li class="dropdown-item">
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="flexRadioInstrMethod" id="flexRadioInstrMethod1" value="In Person">
+                                        <label class="form-check-label" for="flexRadioInstrMethod1">
+                                            In-Person
+                                        </label>
+                                    </div>
+                                </li>
+                                <li class="dropdown-item">
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="flexRadioInstrMethod" id="flexRadioInstrMethod2" value="Hybrid">
+                                        <label class="form-check-label" for="flexRadioInstrMethod2">
+                                            Hybrid
+                                        </label>
+                                    </div>
+                                </li>
+                                <li class="dropdown-item">
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="flexRadioInstrMethod" id="flexRadioInstrMethod3" value="Online">
+                                        <label class="form-check-label" for="flexRadioInstrMethod3">
+                                            Online
+                                        </label>
+                                    </div>
+                                </li>
+                                <li class="dropdown-item">
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="flexRadioInstrMethod" id="flexRadioInstrMethod4" value="Arranged">
+                                        <label class="form-check-label" for="flexRadioInstrMethod4">
+                                            Arranged
+                                        </label>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-3">
+                        <label class="form-label">Open Classes Only</label>
+                        <div>
+                            <input type="checkbox" class="btn-check" id="open-only" autocomplete="off">
+                            <label class="btn btn-outline-success w-100" for="open-only">Show Open Only</label>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-3">
+                        <label class="form-label">Zero Textbook Cost</label>
+                        <div>
+                            <input type="checkbox" class="btn-check" id="ztc-only" autocomplete="off">
+                            <label class="btn btn-outline-primary w-100" for="ztc-only">ZTC Courses</label>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-3">
+                        <label class="form-label d-none d-md-block">&nbsp;</label>
+                        <button type="button" class="btn btn-secondary w-100" id="reset-filters">
+                            <i class="bi bi-arrow-clockwise"></i> Reset Filters
+                        </button>
+                    </div>
+                </div>
+                </div>
+            </form>
+        </div>
+        
+        <!-- Results Container -->
+        <div id="loading-spinner" class="text-center my-5">
+            <div class="spinner-border text-primary" role="status">
+                <span class="visually-hidden">Loading...</span>
+            </div>
+            <p class="mt-2">Loading schedule data...</p>
+        </div>
+
+        <div id="results-container" style="display: none;">
+            <div class="d-flex flex-column flex-sm-row justify-content-between align-items-start align-items-sm-center mb-3 gap-2">
+                <h5 id="result-count" class="mb-0">0 courses found</h5>
+                <div class="btn-group" role="group">
+                    <input type="radio" class="btn-check" name="view-mode" id="card-view" checked>
+                    <label class="btn btn-outline-primary" for="card-view">
+                        <i class="bi bi-grid-3x2-gap"></i> Card View
+                    </label>
+                    <input type="radio" class="btn-check" name="view-mode" id="table-view">
+                    <label class="btn btn-outline-primary" for="table-view">
+                        <i class="bi bi-table"></i> Table View
+                    </label>
+                </div>
+            </div>
+
+            <div id="no-results" class="alert alert-info" style="display: none;">
+                <i class="bi bi-info-circle"></i> No courses found matching your criteria. Try adjusting your filters.
+            </div>
+
+            <div id="card-view-container" class="row g-3"></div>
+            <div id="table-view-container" style="display: none;">
+                <div class="table-responsive">
+                    <table class="table table-hover">
+                        <thead>
+                            <tr>
+                                <th>CRN</th>
+                                <th>Course</th>
+                                <th>Title</th>
+                                <th>Instructor</th>
+                                <th>Days/Times</th>
+                                <th>Location</th>
+                                <th>Units</th>
+                                <th>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody id="table-body"></tbody>
+                    </table>
+                </div>
+            </div>
+
+            <nav aria-label="Search results pagination">
+                <ul class="pagination justify-content-center" id="pagination"></ul>
+            </nav>
+        </div>
+    </div>
+
+    <!-- Section Details Modal -->
+    <div class="modal fade" id="sectionDetailsModal" tabindex="-1" aria-labelledby="sectionDetailsModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="sectionDetailsModalLabel">Section Details</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body" id="sectionDetailsBody">
+                    <!-- Section details will be populated here -->
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="mt-5 py-3 bg-light">
+        <div class="container text-center">
+            <p class="text-muted mb-0">
+                Mt. SAC Schedule Demo | 
+                <a href="https://github.com/jmcpheron/ccc-schedule" target="_blank">CCC Schedule Project</a> | 
+                <a href="https://github.com/jmcpheron/ccc-schedule-collector" target="_blank">Data Collector</a>
+            </p>
+        </div>
+    </footer>
+
+    <!-- Mt. SAC specific JavaScript -->
+    <script src="js/mtsac-schedule.js"></script>
+    <script>
+        // Toggle filters on mobile
+        function toggleFilters() {
+            const filtersSection = document.getElementById('filters-section');
+            const chevron = document.getElementById('filter-chevron');
+            
+            filtersSection.classList.toggle('show');
+            
+            if (filtersSection.classList.contains('show')) {
+                chevron.classList.remove('bi-chevron-down');
+                chevron.classList.add('bi-chevron-up');
+            } else {
+                chevron.classList.remove('bi-chevron-up');
+                chevron.classList.add('bi-chevron-down');
+            }
+        }
+    </script>
+</body>
+</html>

--- a/ccc-schedule-examples/mtsac/js/mtsac-schedule.js
+++ b/ccc-schedule-examples/mtsac/js/mtsac-schedule.js
@@ -1,0 +1,779 @@
+/**
+ * Mt. SAC Schedule JavaScript
+ * Handles the specific data structure from the standardized schedule format
+ */
+
+// Global variables
+let allCourses = [];
+let filteredCourses = [];
+let currentPage = 1;
+const resultsPerPage = 20;
+
+// Initialize on document ready
+$(document).ready(function() {
+    initializeEventHandlers();
+    loadInitialData();
+});
+
+/**
+ * Initialize all event handlers
+ */
+function initializeEventHandlers() {
+    // Search form submission
+    $('#search-form').on('submit', function(e) {
+        e.preventDefault();
+        performSearch();
+    });
+    
+    // Search input keyup
+    $('#search_input_main').on('keyup', function() {
+        if ($(this).val().length !== 1) {
+            performSearch();
+        }
+    });
+    
+    // Search buttons
+    $('#button-search').on('click', function(e) {
+        e.preventDefault();
+        $('#open-only').prop('checked', false);
+        performSearch();
+    });
+    
+    $('#button-search-open').on('click', function(e) {
+        e.preventDefault();
+        $('#open-only').prop('checked', true);
+        performSearch();
+    });
+    
+    // Filter changes
+    $('#term-select, #subject-select, #units-min, #units-max').on('change', performSearch);
+    $('#open-only, #ztc-only').on('change', performSearch);
+    
+    // Instructional mode checkboxes
+    $('input[name="flexRadioInstrMethod"]').on('change', function() {
+        updateDropdownButtonText();
+        performSearch();
+    });
+    
+    // Reset filters
+    $('#reset-filters').on('click', function() {
+        $('#search_input_main').val('');
+        $('#subject-select').val('');
+        $('#units-min').val('');
+        $('#units-max').val('');
+        $('#open-only').prop('checked', false);
+        $('#ztc-only').prop('checked', false);
+        $('input[name="flexRadioInstrMethod"]').prop('checked', false);
+        updateDropdownButtonText();
+        performSearch();
+    });
+    
+    // View mode toggle
+    $('input[name="view-mode"]').on('change', function() {
+        displayResults();
+    });
+    
+    // Handle window resize to update card display
+    let resizeTimer;
+    $(window).on('resize', function() {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(function() {
+            if ($('#card-view').is(':checked')) {
+                displayResults();
+            }
+        }, 250);
+    });
+}
+
+/**
+ * Load initial data
+ */
+function loadInitialData() {
+    // Fetch the latest data directly from the JSON file
+    $.getJSON('https://raw.githubusercontent.com/jmcpheron/ccc-schedule-collector/refs/heads/main/data/mtsac/schedule_202520_latest.json')
+        .done(function(data) {
+            if (data.courses) {
+                // Transform the live data to match expected format
+                allCourses = transformLiveData(data);
+                
+                // Update the data collection date in the UI
+                updateDataCollectionDate(data.collection_timestamp);
+                
+                populateDropdowns();
+                $('#loading-spinner').hide();
+                $('#results-container').show();
+                performSearch();
+            }
+        })
+        .fail(function() {
+            $('#loading-spinner').html('<div class="alert alert-danger">Failed to load schedule data</div>');
+        });
+}
+
+/**
+ * Transform live data format to expected structure
+ */
+function transformLiveData(data) {
+    // Group courses by subject and course number
+    const courseMap = {};
+    
+    data.courses.forEach(course => {
+        const courseKey = `${course.subject}-${course.course_number}`;
+        
+        if (!courseMap[courseKey]) {
+            courseMap[courseKey] = {
+                subject: course.subject,
+                courseNumber: course.course_number,
+                courseId: courseKey,
+                title: course.title,
+                units: course.units,
+                description: '',
+                sections: []
+            };
+        }
+        
+        // Use the status directly from the data
+        let status = course.status || 'OPEN';
+        
+        // Use delivery method from the data
+        let instructionMode = 'ARR';
+        if (course.delivery_method) {
+            if (course.delivery_method.includes('Online')) {
+                instructionMode = 'ONL';
+            } else if (course.delivery_method.includes('Hybrid')) {
+                instructionMode = 'HYB';
+            } else if (course.delivery_method.includes('Person')) {
+                instructionMode = 'INP';
+            } else if (course.delivery_method === 'Arranged') {
+                instructionMode = 'ARR';
+            }
+        }
+        
+        // Transform meetings
+        const meetings = [];
+        if (course.meeting_times && course.meeting_times.length > 0) {
+            course.meeting_times.forEach(meeting => {
+                meetings.push({
+                    days: meeting.days ? (meeting.days === 'ARR' || meeting.days === 'TBA' ? [] : meeting.days.split('')) : [],
+                    start_time: meeting.start_time,
+                    end_time: meeting.end_time,
+                    location: {
+                        building: course.location || 'TBA',
+                        room: ''
+                    }
+                });
+            });
+        }
+        
+        courseMap[courseKey].sections.push({
+            crn: course.crn,
+            status: status,
+            instructionMode: instructionMode,
+            instructor: course.instructor || 'TBA',
+            instructorEmail: course.instructor_email,
+            enrolled: course.enrollment?.actual || 0,
+            capacity: course.enrollment?.capacity || 0,
+            available: course.enrollment?.remaining || 0,
+            meetings: meetings,
+            startDate: course.start_date,
+            endDate: course.end_date,
+            textbookCost: course.textbook_cost === 0 || course.zero_textbook_cost ? 'ZTC' : '',
+            sectionType: course.section_type || '',
+            weeks: course.weeks || '',
+            bookLink: course.book_link || ''
+        });
+    });
+    
+    return Object.values(courseMap);
+}
+
+/**
+ * Update data collection date in the UI
+ */
+function updateDataCollectionDate(timestamp) {
+    if (timestamp) {
+        const date = new Date(timestamp);
+        // Force Pacific Time for California schools
+        const formattedDate = date.toLocaleString('en-US', { 
+            year: 'numeric', 
+            month: 'long', 
+            day: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric',
+            timeZone: 'America/Los_Angeles',
+            timeZoneName: 'short'
+        });
+        
+        // Count total sections (which is what was originally meant by "courses")
+        let totalSections = 0;
+        allCourses.forEach(course => {
+            totalSections += course.sections.length;
+        });
+        
+        // Update the demo notice with the actual collection date and section count
+        $('.text-muted:contains("Data collected on")').html(
+            `Data collected on: ${formattedDate} | ${totalSections} sections available (${allCourses.length} unique courses)`
+        );
+    }
+}
+
+/**
+ * Populate dropdown options
+ */
+function populateDropdowns() {
+    const subjects = [...new Set(allCourses.map(c => c.subject).filter(Boolean))];
+    
+    // Populate subject dropdown
+    $('#subject-select').empty().append('<option value="">All Subjects</option>');
+    subjects.sort().forEach(subject => {
+        $('#subject-select').append(`<option value="${subject}">${subject}</option>`);
+    });
+}
+
+/**
+ * Update instructional mode dropdown button text
+ */
+function updateDropdownButtonText() {
+    const checked = $('input[name="flexRadioInstrMethod"]:checked');
+    if (checked.length === 0) {
+        $('#instr-method-button').text('All Modes');
+    } else if (checked.length === 1) {
+        $('#instr-method-button').text(checked.next('label').text().trim());
+    } else {
+        $('#instr-method-button').text(`${checked.length} selected`);
+    }
+}
+
+/**
+ * Perform search with all filters
+ */
+function performSearch() {
+    const searchTerm = $('#search_input_main').val().toLowerCase();
+    const selectedSubject = $('#subject-select').val();
+    const minUnits = parseFloat($('#units-min').val()) || 0;
+    const maxUnits = parseFloat($('#units-max').val()) || 999;
+    const openOnly = $('#open-only').is(':checked');
+    const ztcOnly = $('#ztc-only').is(':checked');
+    
+    const selectedModes = [];
+    $('input[name="flexRadioInstrMethod"]:checked').each(function() {
+        selectedModes.push($(this).val());
+    });
+    
+    // Filter courses
+    filteredCourses = allCourses.filter(course => {
+        // Search term filter
+        if (searchTerm) {
+            const matchesSearch = 
+                (course.subject && course.subject.toLowerCase().includes(searchTerm)) ||
+                (course.courseNumber && course.courseNumber.toLowerCase().includes(searchTerm)) ||
+                (course.title && course.title.toLowerCase().includes(searchTerm)) ||
+                (course.description && course.description.toLowerCase().includes(searchTerm)) ||
+                (course.sections && course.sections.some(s => 
+                    (s.instructor && s.instructor.toLowerCase().includes(searchTerm)) ||
+                    (s.sectionType && s.sectionType.toLowerCase().includes(searchTerm))
+                )) ||
+                (course.sections && course.sections.some(s => s.crn && s.crn.includes(searchTerm)));
+            
+            if (!matchesSearch) return false;
+        }
+        
+        // Subject filter
+        if (selectedSubject && course.subject !== selectedSubject) return false;
+        
+        // Units filter
+        if (course.units < minUnits || course.units > maxUnits) return false;
+        
+        // Section-based filters
+        const hasMatchingSection = course.sections.some(section => {
+            // Open only filter
+            if (openOnly && section.status !== 'Open') return false;
+            
+            // ZTC filter
+            if (ztcOnly && section.textbookCost !== 'ZTC') return false;
+            
+            // Instructional mode filter
+            if (selectedModes.length > 0) {
+                const modeMap = {
+                    'In Person': ['INP', 'F2F'],
+                    'Hybrid': ['HYB'],
+                    'Online': ['ONL', 'AON', 'SON'],
+                    'Arranged': ['ARR']
+                };
+                
+                let matchesMode = false;
+                for (const mode of selectedModes) {
+                    if (modeMap[mode] && modeMap[mode].includes(section.instructionMode)) {
+                        matchesMode = true;
+                        break;
+                    }
+                }
+                if (!matchesMode) return false;
+            }
+            
+            return true;
+        });
+        
+        return hasMatchingSection;
+    });
+    
+    // Reset to first page
+    currentPage = 1;
+    
+    // Display results
+    displayResults();
+}
+
+/**
+ * Display search results
+ */
+function displayResults() {
+    const start = (currentPage - 1) * resultsPerPage;
+    const end = start + resultsPerPage;
+    const pageResults = filteredCourses.slice(start, end);
+    
+    // Update result count
+    let filteredSections = 0;
+    filteredCourses.forEach(course => {
+        filteredSections += course.sections.length;
+    });
+    $('#result-count').text(`${filteredCourses.length} courses found (${filteredSections} sections)`);
+    
+    // Show/hide no results message
+    if (filteredCourses.length === 0) {
+        $('#no-results').show();
+        $('#card-view-container').hide();
+        $('#table-view-container').hide();
+        $('#pagination').hide();
+    } else {
+        $('#no-results').hide();
+        if ($('#card-view').is(':checked')) {
+            $('#card-view-container').show();
+            $('#table-view-container').hide();
+        } else {
+            $('#card-view-container').hide();
+            $('#table-view-container').show();
+        }
+        $('#pagination').show();
+    }
+    
+    // Clear previous results
+    $('#card-view-container').empty();
+    $('#table-body').empty();
+    
+    // Display courses
+    pageResults.forEach(course => {
+        if ($('#card-view').is(':checked')) {
+            displayCourseCard(course);
+        } else {
+            displayCourseTableRows(course);
+        }
+    });
+    
+    // Update pagination
+    updatePagination();
+}
+
+/**
+ * Display course as card
+ */
+function displayCourseCard(course) {
+    const courseCard = $('<div class="col-12">');
+    const card = $('<div class="card">');
+    
+    // Card header
+    const header = $(`
+        <div class="card-header mtsac-card-header">
+            <h5 class="mb-0">${course.subject} ${course.courseNumber}: ${course.title}</h5>
+            <small>${course.units} Units</small>
+        </div>
+    `);
+    
+    // Card body
+    const body = $('<div class="card-body">');
+    
+    if (course.description) {
+        body.append(`<p class="card-text small">${course.description}</p>`);
+    }
+    
+    // Check if mobile view
+    const isMobile = window.innerWidth < 768;
+    
+    if (isMobile) {
+        // Mobile-friendly section display
+        course.sections.forEach(section => {
+            const sectionDiv = $('<div class="section-mobile section-clickable mb-3 p-2 border rounded">');
+            
+            // CRN and Status on same line
+            const headerRow = $('<div class="d-flex justify-content-between align-items-center mb-1">');
+            headerRow.append(`<strong>CRN: ${section.crn}</strong>`);
+            headerRow.append(`
+                <div>
+                    <span class="badge ${section.status === 'Open' ? 'bg-success' : 'bg-danger'}">
+                        ${section.status}
+                    </span>
+                    ${section.textbookCost === 'ZTC' ? '<span class="badge bg-info ms-1">ZTC</span>' : ''}
+                </div>
+            `);
+            sectionDiv.append(headerRow);
+            
+            // Instructor
+            const instructorDisplay = section.instructor + 
+                (section.instructorEmail && section.instructorEmail !== null ? 
+                    ` <a href="mailto:${section.instructorEmail}" title="Email" class="email-link"><i class="bi bi-envelope-fill"></i></a>` : 
+                    '');
+            sectionDiv.append(`<div class="small"><strong>Instructor:</strong> ${instructorDisplay}</div>`);
+            
+            // Meeting info
+            const meetingInfo = formatMeetingInfo(section.meetings);
+            const location = formatLocation(section.meetings);
+            sectionDiv.append(`<div class="small"><strong>Time:</strong> ${meetingInfo}</div>`);
+            sectionDiv.append(`<div class="small"><strong>Location:</strong> ${location}</div>`);
+            sectionDiv.append(`<div class="small"><strong>Type:</strong> ${section.sectionType || 'LEC'}</div>`);
+            sectionDiv.append(`<div class="small"><strong>Mode:</strong> ${formatInstructionMode(section.instructionMode)}</div>`);
+            if (section.weeks) {
+                sectionDiv.append(`<div class="small"><strong>Duration:</strong> ${section.weeks} weeks</div>`);
+            }
+            
+            // Add click handler for this section
+            sectionDiv.on('click', function(e) {
+                if (!$(e.target).closest('.email-link').length) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    showSectionDetails(course, section);
+                }
+            });
+            
+            body.append(sectionDiv);
+        });
+    } else {
+        // Desktop table view
+        const sectionsTable = $(`
+            <table class="table table-sm mb-0">
+                <thead>
+                    <tr>
+                        <th>CRN</th>
+                        <th>Instructor</th>
+                        <th>Days/Times</th>
+                        <th>Location</th>
+                        <th>Type</th>
+                        <th>Mode</th>
+                        <th>Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                </tbody>
+            </table>
+        `);
+        
+        course.sections.forEach(section => {
+            const meetingInfo = formatMeetingInfo(section.meetings);
+            const location = formatLocation(section.meetings);
+            const instructorDisplay = section.instructor + 
+                (section.instructorEmail && section.instructorEmail !== null ? 
+                    ` <a href="mailto:${section.instructorEmail}" title="Email instructor" class="email-link"><i class="bi bi-envelope-fill"></i></a>` : 
+                    '');
+            
+            const row = $(`
+                <tr class="section-clickable">
+                    <td>${section.crn}</td>
+                    <td>${instructorDisplay}</td>
+                    <td>${meetingInfo}</td>
+                    <td>${location}</td>
+                    <td>${section.sectionType || 'LEC'}</td>
+                    <td>${formatInstructionMode(section.instructionMode)}</td>
+                    <td>
+                        <span class="badge ${section.status === 'Open' ? 'bg-success' : 'bg-danger'}">
+                            ${section.status}
+                        </span>
+                        ${section.textbookCost === 'ZTC' ? '<span class="badge bg-info ms-1">ZTC</span>' : ''}
+                    </td>
+                </tr>
+            `);
+            
+            // Add click handler for this row
+            row.on('click', function(e) {
+                if (!$(e.target).closest('.email-link').length) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    showSectionDetails(course, section);
+                }
+            });
+            
+            sectionsTable.find('tbody').append(row);
+        });
+        
+        body.append(sectionsTable);
+    }
+    
+    card.append(header).append(body);
+    courseCard.append(card);
+    $('#card-view-container').append(courseCard);
+}
+
+/**
+ * Display course as table rows
+ */
+function displayCourseTableRows(course) {
+    course.sections.forEach(section => {
+        const meetingInfo = formatMeetingInfo(section.meetings);
+        const location = formatLocation(section.meetings);
+        const instructorDisplay = section.instructor + 
+            (section.instructorEmail && section.instructorEmail !== null ? 
+                ` <a href="mailto:${section.instructorEmail}" title="Email instructor" class="email-link"><i class="bi bi-envelope-fill"></i></a>` : 
+                '');
+        
+        const row = $(`
+            <tr class="section-clickable">
+                <td>${section.crn}</td>
+                <td>${course.subject} ${course.courseNumber}</td>
+                <td>${course.title}</td>
+                <td>${instructorDisplay}</td>
+                <td>${meetingInfo}</td>
+                <td>${location}</td>
+                <td>${course.units}</td>
+                <td>
+                    <span class="badge ${section.status === 'Open' ? 'bg-success' : 'bg-danger'}">
+                        ${section.status}
+                    </span>
+                    ${section.textbookCost === 'ZTC' ? '<span class="badge bg-info ms-1">ZTC</span>' : ''}
+                </td>
+            </tr>
+        `);
+        
+        // Add click handler
+        row.on('click', function(e) {
+            // Prevent click on email links from opening modal
+            if ($(e.target).closest('.email-link').length === 0) {
+                showSectionDetails(course, section);
+            }
+        });
+        
+        $('#table-body').append(row);
+    });
+}
+
+/**
+ * Format meeting information
+ */
+function formatMeetingInfo(meetings) {
+    if (!meetings || meetings.length === 0) return 'TBA';
+    
+    const meeting = meetings[0];
+    
+    if (!meeting.days || meeting.days.length === 0) {
+        return 'Arranged';
+    }
+    
+    const days = meeting.days.join('');
+    const time = meeting.start_time && meeting.end_time ? 
+        `${formatTime(meeting.start_time)} - ${formatTime(meeting.end_time)}` : 
+        'TBA';
+    
+    return `${days} ${time}`;
+}
+
+/**
+ * Format time from 24-hour to 12-hour format
+ */
+function formatTime(time) {
+    if (!time) return '';
+    // Mt. SAC data already includes AM/PM format
+    return time;
+}
+
+/**
+ * Format instruction mode
+ */
+function formatInstructionMode(mode) {
+    const modeMap = {
+        'INP': 'In-Person',
+        'F2F': 'In-Person',
+        'HYB': 'Hybrid',
+        'ONL': 'Online',
+        'AON': 'Online Async',
+        'SON': 'Online Sync',
+        'ARR': 'Arranged'
+    };
+    return modeMap[mode] || mode;
+}
+
+/**
+ * Format location information
+ */
+function formatLocation(meetings) {
+    if (!meetings || meetings.length === 0) return 'TBA';
+    
+    const meeting = meetings[0];
+    if (!meeting.location) return 'TBA';
+    
+    const building = meeting.location.building || 'TBA';
+    const room = meeting.location.room || '';
+    
+    if (building === 'Online' || building === 'TBD') {
+        return building;
+    }
+    
+    return room ? `${building} ${room}` : building;
+}
+
+/**
+ * Update pagination
+ */
+function updatePagination() {
+    const totalPages = Math.ceil(filteredCourses.length / resultsPerPage);
+    
+    $('#pagination').empty();
+    
+    // Previous button
+    const prevClass = currentPage === 1 ? 'disabled' : '';
+    $('#pagination').append(`
+        <li class="page-item ${prevClass}">
+            <a class="page-link" href="#" data-page="${currentPage - 1}">Previous</a>
+        </li>
+    `);
+    
+    // Page numbers
+    for (let i = 1; i <= totalPages; i++) {
+        if (i === 1 || i === totalPages || (i >= currentPage - 2 && i <= currentPage + 2)) {
+            const activeClass = i === currentPage ? 'active' : '';
+            $('#pagination').append(`
+                <li class="page-item ${activeClass}">
+                    <a class="page-link" href="#" data-page="${i}">${i}</a>
+                </li>
+            `);
+        } else if (i === currentPage - 3 || i === currentPage + 3) {
+            $('#pagination').append('<li class="page-item disabled"><span class="page-link">...</span></li>');
+        }
+    }
+    
+    // Next button
+    const nextClass = currentPage === totalPages ? 'disabled' : '';
+    $('#pagination').append(`
+        <li class="page-item ${nextClass}">
+            <a class="page-link" href="#" data-page="${currentPage + 1}">Next</a>
+        </li>
+    `);
+    
+    // Pagination click handlers
+    $('#pagination').on('click', 'a.page-link', function(e) {
+        e.preventDefault();
+        const page = parseInt($(this).data('page'));
+        if (page && page !== currentPage && page >= 1 && page <= totalPages) {
+            currentPage = page;
+            displayResults();
+            $('html, body').animate({ scrollTop: $('#results-container').offset().top - 100 }, 300);
+        }
+    });
+}
+
+/**
+ * Show section details in modal
+ */
+function showSectionDetails(course, section) {
+    console.log('showSectionDetails called', course, section);
+    
+    // Build the modal content
+    let modalContent = `
+        <div class="container-fluid">
+            <div class="row mb-3">
+                <div class="col-12">
+                    <h4>${course.subject} ${course.courseNumber}: ${course.title}</h4>
+                    <p class="text-muted mb-0">${course.units} Units</p>
+                </div>
+            </div>
+            
+            <div class="row">
+                <div class="col-md-6">
+                    <h6 class="border-bottom pb-2">Section Information</h6>
+                    <dl class="row">
+                        <dt class="col-sm-4">CRN:</dt>
+                        <dd class="col-sm-8">${section.crn}</dd>
+                        
+                        <dt class="col-sm-4">Status:</dt>
+                        <dd class="col-sm-8">
+                            <span class="badge ${section.status === 'Open' ? 'bg-success' : 'bg-danger'}">
+                                ${section.status}
+                            </span>
+                        </dd>
+                        
+                        <dt class="col-sm-4">Section Type:</dt>
+                        <dd class="col-sm-8">${section.sectionType || 'LEC'}</dd>
+                        
+                        <dt class="col-sm-4">Enrollment:</dt>
+                        <dd class="col-sm-8">${section.enrolled} / ${section.capacity} (${section.available} available)</dd>
+                        
+                        <dt class="col-sm-4">Instruction Mode:</dt>
+                        <dd class="col-sm-8">${formatInstructionMode(section.instructionMode)}</dd>
+                        
+                        ${section.textbookCost === 'ZTC' ? `
+                        <dt class="col-sm-4">Textbook:</dt>
+                        <dd class="col-sm-8"><span class="badge bg-info">Zero Textbook Cost</span></dd>
+                        ` : ''}
+                    </dl>
+                </div>
+                
+                <div class="col-md-6">
+                    <h6 class="border-bottom pb-2">Instructor & Schedule</h6>
+                    <dl class="row">
+                        <dt class="col-sm-4">Instructor:</dt>
+                        <dd class="col-sm-8">
+                            ${section.instructor}
+                            ${section.instructorEmail && section.instructorEmail !== null ? 
+                                `<br><a href="mailto:${section.instructorEmail}"><i class="bi bi-envelope-fill"></i> ${section.instructorEmail}</a>` : 
+                                ''}
+                        </dd>
+                        
+                        <dt class="col-sm-4">Days/Times:</dt>
+                        <dd class="col-sm-8">${formatMeetingInfo(section.meetings)}</dd>
+                        
+                        <dt class="col-sm-4">Location:</dt>
+                        <dd class="col-sm-8">${formatLocation(section.meetings)}</dd>
+                        
+                        ${section.startDate ? `
+                        <dt class="col-sm-4">Dates:</dt>
+                        <dd class="col-sm-8">${section.startDate} - ${section.endDate}</dd>
+                        ` : ''}
+                        
+                        ${section.weeks ? `
+                        <dt class="col-sm-4">Duration:</dt>
+                        <dd class="col-sm-8">${section.weeks} weeks</dd>
+                        ` : ''}
+                        
+                        ${section.bookLink ? `
+                        <dt class="col-sm-4">Textbook:</dt>
+                        <dd class="col-sm-8"><a href="${section.bookLink}" target="_blank" class="btn btn-sm btn-outline-primary"><i class="bi bi-book"></i> View Book Info</a></dd>
+                        ` : ''}
+                    </dl>
+                </div>
+            </div>
+            
+            ${course.description ? `
+            <div class="row mt-3">
+                <div class="col-12">
+                    <h6 class="border-bottom pb-2">Course Description</h6>
+                    <p>${course.description}</p>
+                </div>
+            </div>
+            ` : ''}
+        </div>
+    `;
+    
+    // Update modal title and body
+    $('#sectionDetailsModalLabel').text(`${course.subject} ${course.courseNumber} - Section ${section.crn}`);
+    $('#sectionDetailsBody').html(modalContent);
+    
+    // Show the modal
+    try {
+        const modalElement = document.getElementById('sectionDetailsModal');
+        if (!modalElement) {
+            console.error('Modal element not found');
+            return;
+        }
+        const modal = new bootstrap.Modal(modalElement);
+        modal.show();
+        console.log('Modal shown');
+    } catch (error) {
+        console.error('Error showing modal:', error);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a new Mt. SAC (Mount San Antonio College) schedule demo to the CCC Schedule project, expanding our collection of college demos alongside Citrus, Rio Hondo, and others.

### Key Changes

- **New Mt. SAC Demo**: Created a complete schedule viewer demo for Mt. SAC Fall 2025
- **Brand Integration**: Implemented official Mt. SAC colors (maroon #9c182f, gold #ffcd5b) throughout the interface
- **Template-Based Development**: Built on the proven Citrus College template structure
- **Data Integration**: Configured to fetch Mt. SAC Fall 2025 data (term 202520) from the standardized collector
- **UI Consistency**: Replaced all default Bootstrap blue colors with Mt. SAC maroon theming
- **Full Functionality**: Maintains all core features including search, filtering, responsive design, card/table views, and modal details

### Files Added

- `ccc-schedule-examples/mtsac/index.html` (568 lines) - Main HTML interface with Mt. SAC branding
- `ccc-schedule-examples/mtsac/js/mtsac-schedule.js` (779 lines) - JavaScript functionality for data handling and UI interactions

### Technical Details

- Responsive design optimized for mobile and desktop
- Bootstrap 5 integration with custom Mt. SAC color overrides
- jQuery-based interactivity for search and filtering
- Modal-based course detail views
- Card and table view options for course listings
- Advanced filtering by term, subject, units, availability, and ZTC status

## Test Plan

### Manual Testing Checklist

#### Basic Functionality
- [ ] Navigate to the Mt. SAC demo page
- [ ] Verify Mt. SAC branding is properly displayed (maroon header, gold accents)
- [ ] Confirm course data loads successfully from the collector
- [ ] Test search functionality with various course names and numbers
- [ ] Verify "Search Open Only" button filters to available courses

#### Filtering & Display
- [ ] Test subject dropdown filtering
- [ ] Verify units range filtering (min/max)
- [ ] Test "Open Only" checkbox filtering
- [ ] Test "ZTC Only" (Zero Textbook Cost) filtering
- [ ] Switch between card view and table view layouts
- [ ] Verify responsive design on mobile devices

#### Course Details
- [ ] Click on course cards to open detail modals
- [ ] Verify all course information displays correctly (instructor, schedule, location, etc.)
- [ ] Test modal close functionality
- [ ] Verify course availability status indicators

#### Visual Design
- [ ] Confirm Mt. SAC maroon (#9c182f) is used for primary elements
- [ ] Verify gold (#ffcd5b) accent color in appropriate places
- [ ] Test that hover states and active elements maintain brand consistency
- [ ] Ensure demo notice banner is clearly visible

#### Cross-Browser Testing
- [ ] Test in Chrome/Chromium
- [ ] Test in Firefox
- [ ] Test in Safari
- [ ] Verify mobile responsiveness across devices

### Expected Behavior

The Mt. SAC demo should function identically to existing college demos (Citrus, Rio Hondo) but with Mt. SAC-specific:
- Branding and color scheme
- Data source (Mt. SAC Fall 2025 schedule)
- College name and styling throughout the interface

### Regression Testing

Since this is an additive change that doesn't modify existing functionality, no regression testing of other demos is required. However, verify that:
- The main project structure remains unchanged
- Other college demos continue to function normally
- No shared CSS or JavaScript files were modified

🤖 Generated with [Claude Code](https://claude.ai/code)